### PR TITLE
Patch bug in FileContainer.concat: switch to `pd.Index.equals()` instead of `is` comparison for equal keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v1.0.1 - unreleased
 
+- compare keys of two `FileContainer`s with `pandas.Index.equals()` instead of `is` in `FileContainer.concat()` ([#145](https://github.com/mpytools/filefisher/pull/145)) - this fixes a bug where no two FileContainers that are not the same object could be concatenated together, see [Github issue](https://github.com/mpytools/filefisher/issues/143).
 
 ## v1.0.0 - 07.01.2025
 

--- a/filefisher/_filefinder.py
+++ b/filefisher/_filefinder.py
@@ -714,13 +714,13 @@ class FileContainer:
         ValueError
             If the other object is not a FileContainer.
         ValueError
-            If the two FileContainers do not have the same keys.
+            If the two FileContainers do not have the same keys (in the same order).
         """
 
         if not isinstance(other, FileContainer):
             raise ValueError("Can only concatenate two FileContainers.")
 
-        if self.df.columns is not other.df.columns:
+        if not self.df.columns.equals(other.df.columns):
             raise ValueError("FileContainers must have the same keys.")
 
         df = pd.concat([self.df, other.df])

--- a/filefisher/tests/test_filecontainer.py
+++ b/filefisher/tests/test_filecontainer.py
@@ -164,17 +164,18 @@ def test_filecontainer_concat(example_fc):
     with pytest.raises(ValueError, match="Can only concatenate two FileContainers."):
         example_fc.concat("not a FileContainer")
 
+    example_fc_2 = FileContainer(example_fc.df)
     with pytest.raises(ValueError, match="FileContainers must have the same keys"):
-        different_keys_fc = FileContainer(example_fc.df.loc[:, ["model", "scen"]])
+        different_keys_fc = FileContainer(example_fc_2.df.loc[:, ["model", "scen"]])
         example_fc.concat(different_keys_fc)
 
-    result = example_fc.concat(example_fc, drop_duplicates=False)
-    expected = pd.concat([example_fc.df, example_fc.df])
+    result = example_fc.concat(example_fc_2, drop_duplicates=False)
+    expected = pd.concat([example_fc.df, example_fc_2.df])
 
     pd.testing.assert_frame_equal(result.df, expected)
     assert len(result) == 10
 
-    result = example_fc.concat(example_fc, drop_duplicates=True)
+    result = example_fc.concat(example_fc_2, drop_duplicates=True)
     expected = example_fc
 
     pd.testing.assert_frame_equal(result.df, expected.df)


### PR DESCRIPTION
Closes #143 