### PR TITLE
upgrade code and fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v1.0.2 - unreleased
 
 - Restore behavior of `FileContainer.search(key=None)` - passing `None` to `search` is ignored again [#143](https://github.com/mpytools/filefisher/issues/143).
-- Added `FileContainer.search_single` to search for _exacly_ one path in a `FileContainer` ([#158](https://github.com/mpytools/filefisher/pull/158)).
+- Added `FileContainer.search_single` to search for _exactly_ one path in a `FileContainer` ([#158](https://github.com/mpytools/filefisher/pull/158)).
 
 ## v1.0.1 - 16.01.205
 This version patches a bug from v1.0.0. that broke `FileContainer.concat()`.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,9 +37,7 @@ if on_rtd:
 
 project = "filefisher"
 copyright_year = datetime.date.today().year
-copyright = (
-    f"(c) 2024-{copyright_year} Mathias Hauser"
-)
+copyright = f"(c) 2024-{copyright_year} Mathias Hauser"
 
 authors = "Mathias Hauser"
 author = authors

--- a/filefisher/_filefinder.py
+++ b/filefisher/_filefinder.py
@@ -4,7 +4,8 @@ import logging
 import os
 import re
 import warnings
-from typing import Any, Generator
+from typing import Any
+from collections.abc import Generator
 
 import numpy as np
 import pandas as pd
@@ -98,7 +99,7 @@ class _FinderBase:
 class _Finder(_FinderBase):
     def _create_condition_dict(self, **kwargs):
 
-        # add wildcard for all undefinded keys
+        # add wildcard for all undefined keys
         cond_dict = dict.fromkeys(self.keys, "*")
         cond_dict.update(**kwargs)
 
@@ -643,7 +644,7 @@ class FileContainer:
         Returns
         -------
         pd.Series
-            pd.Series with combined columns where the keys are seperated by `sep`.
+            pd.Series with combined columns where the keys are separated by `sep`.
 
         """
         warnings.warn(
@@ -666,7 +667,7 @@ class FileContainer:
         Returns
         -------
         pd.Series
-            pd.Series with combined columns where the keys are seperated by `sep`.
+            pd.Series with combined columns where the keys are separated by `sep`.
 
         """
 

--- a/filefisher/tests/__init__.py
+++ b/filefisher/tests/__init__.py
@@ -1,6 +1,6 @@
 import warnings
 from contextlib import contextmanager
-from typing import Iterable
+from collections.abc import Iterable
 
 import pandas as pd
 

--- a/filefisher/tests/test_filecontainer.py
+++ b/filefisher/tests/test_filecontainer.py
@@ -176,10 +176,10 @@ def test_filecontainer_search_single(example_df, example_fc):
     with pytest.raises(ValueError, match="Found no paths"):
         example_fc.search_single()
 
-    with pytest.raises(ValueError, match="Found more than one \(5\) paths"):
+    with pytest.raises(ValueError, match=r"Found more than one \(5\) paths"):
         example_fc.search_single(model=None)
 
-    with pytest.raises(ValueError, match="Found more than one \(2\) paths"):
+    with pytest.raises(ValueError, match=r"Found more than one \(2\) paths"):
         example_fc.search_single(model="a")
 
     result = example_fc.search_single(model="a", scen="h")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,10 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]
 fallback_version = "999"
 version_scheme = "no-guess-dev"
+
+[tool.typos]
+
+[tool.typos.default]
+extend-ignore-identifiers-re = [
+  "varn",
+]


### PR DESCRIPTION
update code
```
black .
find . -name "*.py" -exec pyupgrade --py310-plus {} \;
```

autofix typos
```
codespell --skip=".git,devel,_build" --ignore-words-list "varn" . --write-changes -i 3
typos . --write-changes
```