### PR TITLE
fix dependency groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,8 @@ tests = [
     "pytest",
 ]
 dev = [
-    "regionmask[docs, tests]",
+    {include-group = "docs"},
+    {include-group = "tests"},
     "black !=23",
     "ruff",
 ]


### PR DESCRIPTION
@veni-vidi-vici-dormivi 

With #174 I also added "dependency groups", which is a relatively new feature. These can be used instead of optional dependencies ("extras") for development dependencies. The idea is that these are not available to install from pypi (in contrast to the extras) but only locally when the _pyproject.toml_ file is available. It requires a new version of pip (25.1) and the syntax changed:

```diff
-python -m pip install -e .[dev]
+python -m pip install -e . --group dev
```