### PR TITLE
type filefisher

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,7 +9,7 @@ import datetime
 import os
 import subprocess
 import sys
-from importlib.metadata import version
+from importlib.metadata import version as _get_version
 
 import filefisher
 
@@ -43,7 +43,7 @@ authors = "Mathias Hauser"
 author = authors
 
 # The full version, including alpha/beta/rc tags
-release = version("filefisher")
+release = _get_version("filefisher")
 # The short X.Y version
 version = ".".join(release.split(".")[:2])
 
@@ -82,7 +82,7 @@ templates_path = ["_templates"]
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = []
+exclude_patterns: list[str] = []
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/filefisher/_filefinder.py
+++ b/filefisher/_filefinder.py
@@ -224,7 +224,7 @@ class _Finder(_FinderBase):
         return fc
 
     @staticmethod
-    def _glob(pattern) -> list[str]:
+    def _glob(pattern:str) -> list[str]:
         """Return a list of paths matching a pathname pattern
 
         Notes
@@ -239,7 +239,8 @@ class _Finder(_FinderBase):
         self, paths, on_parse_error: ON_PARSE_ERROR_OPTIONS
     ) -> pd.DataFrame:
 
-        valid_paths, out = list(), list()
+        valid_paths: list[str] = list()
+        out = list()
         for path in paths:
             parsed = self.parser.parse(path)
 
@@ -258,6 +259,7 @@ class _Finder(_FinderBase):
                     pass
             else:
                 valid_paths.append(path)
+                parsed = cast(parse.Result, parsed)
                 out.append(list(parsed.named.values()))
 
         index = pd.Index(valid_paths, name="path") + self._suffix
@@ -328,10 +330,10 @@ class FileFinder:
         self._test_paths = test_paths
 
         # use fnmatch.filter to 'glob' pseudo-filenames
-        def finder(pat):
+        def finder(pattern: str) -> list[str]:
 
             # make fnmatch work (almost) the same as glob
-            if pat.endswith(os.path.sep):
+            if pattern.endswith(os.path.sep):
                 # remove duplicate paths (i.e. if the filename made it non-unique)
                 paths_ = sorted(
                     set(os.path.dirname(s) + os.path.sep for s in test_paths)
@@ -339,7 +341,7 @@ class FileFinder:
             else:
                 paths_ = test_paths
 
-            return fnmatch.filter(paths_, pat)
+            return fnmatch.filter(paths_, pattern)
 
         # overwrite the glob implementation
         self.path._glob = finder
@@ -835,9 +837,9 @@ class FileContainer:
         msg = f"<FileContainer: {n_paths} paths>\n"
         return msg + self.df.__repr__()
 
-    def _repr_html_(self):
+    def _repr_html_(self) -> str:
 
         n_paths = len(self)
 
         msg = f"filefisher.FileContainer: {n_paths} paths<br><hr><br>"
-        return msg + self.df._repr_html_()
+        return msg + self.df._repr_html_() # type: ignore[operator]

--- a/filefisher/_filefinder.py
+++ b/filefisher/_filefinder.py
@@ -5,7 +5,7 @@ import os
 import re
 import warnings
 from collections.abc import Generator
-from typing import Any
+from typing import Any, Literal, cast
 
 import numpy as np
 import pandas as pd
@@ -28,8 +28,11 @@ file_pattern: '{file_pattern}'
 keys: {repr_keys}
 """
 
+ON_PARSE_ERROR_OPTIONS = Literal["raise", "warn", "ignore"]
+ON_EMPTY_OPTIONS = Literal["raise", "warn", "allow"]
 
-def _deprecate_allow_empty(**kwargs):
+
+def _deprecate_allow_empty(**kwargs) -> None:
 
     _allow_empty = kwargs.get("_allow_empty")
 
@@ -59,7 +62,7 @@ def _assert_unique(df) -> None:
 
 
 class _FinderBase:
-    def __init__(self, pattern, suffix=""):
+    def __init__(self, pattern, suffix="") -> None:
 
         self.pattern = pattern
         self.keys = _find_keys(pattern)
@@ -107,7 +110,12 @@ class _Finder(_FinderBase):
         return cond_dict
 
     def find(
-        self, keys=None, *, on_parse_error="raise", on_empty="raise", **keys_kwargs
+        self,
+        keys=None,
+        *,
+        on_parse_error: ON_PARSE_ERROR_OPTIONS = "raise",
+        on_empty: ON_EMPTY_OPTIONS = "raise",
+        **keys_kwargs,
     ) -> "FileContainer":
         """find files in the file system using the file and path (folder) pattern
 
@@ -227,7 +235,9 @@ class _Finder(_FinderBase):
 
         return glob.glob(pattern)
 
-    def _parse_paths(self, paths, on_parse_error) -> pd.DataFrame:
+    def _parse_paths(
+        self, paths, on_parse_error: ON_PARSE_ERROR_OPTIONS
+    ) -> pd.DataFrame:
 
         valid_paths, out = list(), list()
         for path in paths:
@@ -258,7 +268,7 @@ class _Finder(_FinderBase):
 class FileFinder:
 
     def __init__(
-        self, path_pattern: str, file_pattern: str, *, test_paths=None
+        self, path_pattern: str | os.PathLike, file_pattern: str, *, test_paths=None
     ) -> None:
         """find and create file names based on python format syntax
 
@@ -291,7 +301,7 @@ class FileFinder:
         self.file = _FinderBase(file_pattern)
         # ensure path_pattern ends with a /
         self.path = _Finder(os.path.join(path_pattern, ""), suffix="*")
-        self.full = _Finder(os.path.join(*filter(None, (path_pattern, file_pattern))))
+        self.full = _Finder(os.path.join(path_pattern, file_pattern))
 
         self.keys_path = self.path.keys
         self.keys_file = self.file.keys
@@ -426,7 +436,12 @@ class FileFinder:
         return self.full.create_name(keys, **keys_kwargs)
 
     def find_paths(
-        self, keys=None, *, on_parse_error="raise", on_empty="raise", **keys_kwargs
+        self,
+        keys=None,
+        *,
+        on_parse_error: ON_PARSE_ERROR_OPTIONS = "raise",
+        on_empty: ON_EMPTY_OPTIONS = "raise",
+        **keys_kwargs,
     ) -> "FileContainer":
         """find files in the file system using the file and path (folder) pattern
 
@@ -476,7 +491,12 @@ class FileFinder:
         )
 
     def find_files(
-        self, keys=None, *, on_parse_error="raise", on_empty="raise", **keys_kwargs
+        self,
+        keys=None,
+        *,
+        on_parse_error: ON_PARSE_ERROR_OPTIONS = "raise",
+        on_empty: ON_EMPTY_OPTIONS = "raise",
+        **keys_kwargs,
     ) -> "FileContainer":
         """find files in the file system using the file pattern
 
@@ -596,7 +616,7 @@ class FileFinder:
 
 class FileContainer:
 
-    def __init__(self, df: pd.DataFrame):
+    def __init__(self, df: pd.DataFrame) -> None:
         """FileContainer gathers paths and their metadata
 
         Parameters
@@ -634,7 +654,9 @@ class FileContainer:
     @property
     def meta(self) -> list[dict[str, Any]]:
         """Return metadata as list of dictionaries"""
-        return self.df.to_dict("records")
+        records = self.df.to_dict("records")
+        records = cast(list[dict[str, Any]], records)
+        return records
 
     @property
     def paths(self) -> list[str]:
@@ -644,6 +666,7 @@ class FileContainer:
     def items(self) -> Generator[tuple[str, dict[str, Any]], None, None]:
         """Return a generator of (path, metadata) tuples"""
         for index, element in self.df.iterrows():
+            index = cast(str, index)
             yield index, element.to_dict()
 
     def combine_by_key(self, keys=None, sep="."):
@@ -748,7 +771,7 @@ class FileContainer:
 
         return fc
 
-    def concat(self, other, drop_duplicates=True):
+    def concat(self, other, drop_duplicates=True) -> "FileContainer":
         """concatenate two FileContainers
 
         Parameters
@@ -784,7 +807,7 @@ class FileContainer:
 
         return type(self)(df)
 
-    def _get_subset(self, **query):
+    def _get_subset(self, **query) -> pd.DataFrame:
         if not query:
             return pd.DataFrame(
                 [], columns=self.df.columns, index=pd.Index([], name="path")
@@ -802,12 +825,19 @@ class FileContainer:
 
         return self.df[sel]
 
-    def __len__(self):
+    def __len__(self) -> int:
         return self.df.__len__()
 
-    def __repr__(self):
+    def __repr__(self) -> str:
 
         n_paths = len(self)
 
         msg = f"<FileContainer: {n_paths} paths>\n"
         return msg + self.df.__repr__()
+
+    def _repr_html_(self):
+
+        n_paths = len(self)
+
+        msg = f"filefisher.FileContainer: {n_paths} paths<br><hr><br>"
+        return msg + self.df._repr_html_()

--- a/filefisher/_filefinder.py
+++ b/filefisher/_filefinder.py
@@ -224,7 +224,7 @@ class _Finder(_FinderBase):
         return fc
 
     @staticmethod
-    def _glob(pattern:str) -> list[str]:
+    def _glob(pattern: str) -> list[str]:
         """Return a list of paths matching a pathname pattern
 
         Notes
@@ -842,4 +842,4 @@ class FileContainer:
         n_paths = len(self)
 
         msg = f"filefisher.FileContainer: {n_paths} paths<br><hr><br>"
-        return msg + self.df._repr_html_() # type: ignore[operator]
+        return msg + self.df._repr_html_()  # type: ignore[operator]

--- a/filefisher/_filefinder.py
+++ b/filefisher/_filefinder.py
@@ -841,5 +841,5 @@ class FileContainer:
 
         n_paths = len(self)
 
-        msg = f"filefisher.FileContainer: {n_paths} paths<br><hr><br>"
+        msg = f"<pre>&lt;filefisher.FileContainer: {n_paths} paths&gt;</pre>"
         return msg + self.df._repr_html_() # type: ignore[operator]

--- a/filefisher/_filefinder.py
+++ b/filefisher/_filefinder.py
@@ -842,4 +842,4 @@ class FileContainer:
         n_paths = len(self)
 
         msg = f"<pre>&lt;filefisher.FileContainer: {n_paths} paths&gt;</pre>"
-        return msg + self.df._repr_html_() # type: ignore[operator]
+        return msg + self.df._repr_html_()  # type: ignore[operator]

--- a/filefisher/_filefinder.py
+++ b/filefisher/_filefinder.py
@@ -62,7 +62,7 @@ def _assert_unique(df) -> None:
 
 
 class _FinderBase:
-    def __init__(self, pattern, suffix="") -> None:
+    def __init__(self, pattern: str, suffix: str="") -> None:
 
         self.pattern = pattern
         self.keys = _find_keys(pattern)
@@ -162,8 +162,8 @@ class _Finder(_FinderBase):
             if isinstance(value, str) or np.ndim(value) == 0:
                 keys[key] = [value]
 
-        all_paths = list()
-        all_patterns = list()
+        all_paths: list[str] = list()
+        all_patterns: list[str] = list()
         for one_search_dict in product_dict(**keys):
 
             cond_dict = self._create_condition_dict(**one_search_dict)

--- a/filefisher/_filefinder.py
+++ b/filefisher/_filefinder.py
@@ -62,7 +62,7 @@ def _assert_unique(df) -> None:
 
 
 class _FinderBase:
-    def __init__(self, pattern: str, suffix: str="") -> None:
+    def __init__(self, pattern: str, suffix: str = "") -> None:
 
         self.pattern = pattern
         self.keys = _find_keys(pattern)

--- a/filefisher/_utils.py
+++ b/filefisher/_utils.py
@@ -7,7 +7,7 @@ import warnings
 import pandas as pd
 
 
-def _find_keys(string):
+def _find_keys(string) -> tuple[str]:
     """find keys in a format string
 
     find all keys enclosed by curly brackets
@@ -33,11 +33,11 @@ def _find_keys(string):
     return keys
 
 
-def atoi(text):
+def atoi(text: str) -> int | str:
     return int(text) if text.isdigit() else text
 
 
-def natural_keys(text):
+def natural_keys(text: str) -> list[int | str]:
     """key for natural sorting order
 
     Examples
@@ -98,7 +98,7 @@ def update_dict_with_kwargs(dictionary, /, **kwargs):
     return (dictionary or {}) | kwargs
 
 
-def emit_user_level_warning(message, category=None) -> None:
+def emit_user_level_warning(message: str, category=None) -> None:
     """emit a warning at the user level"""
 
     # skip_file_prefixes only defined in python 3.12

--- a/filefisher/tests/__init__.py
+++ b/filefisher/tests/__init__.py
@@ -17,7 +17,7 @@ def assert_no_warnings():
 
 def assert_filecontainer_empty(
     fc: FileContainer, columns: str | Iterable[str] | None = None
-):
+) -> None:
     """checks passed object is an empty `FileContainer`
 
     Parameters

--- a/filefisher/tests/test_cmip.py
+++ b/filefisher/tests/test_cmip.py
@@ -4,7 +4,7 @@ from filefisher import FileContainer
 from filefisher.cmip import create_ensnumber, ensure_unique_grid, parse_ens
 
 
-def test_parse_ens_cmip5():
+def test_parse_ens_cmip5() -> None:
 
     # pattern: "r{r}i{i}p{p}"
 
@@ -38,7 +38,7 @@ def test_parse_ens_cmip5():
     pd.testing.assert_frame_equal(result.df, expected_df)
 
 
-def test_parse_ens_cmip6():
+def test_parse_ens_cmip6() -> None:
 
     # pattern: "r{r}i{i}p{p}f{f}"
 
@@ -72,7 +72,7 @@ def test_parse_ens_cmip6():
     pd.testing.assert_frame_equal(result.df, expected_df)
 
 
-def test_create_ensnumber():
+def test_create_ensnumber() -> None:
     columns = ("path", "model", "exp", "table", "varn", "ens")
 
     common = ("exp", "table", "varn")
@@ -104,7 +104,7 @@ def test_create_ensnumber():
     pd.testing.assert_frame_equal(result.df, expected_df)
 
 
-def test_ensure_unique_grid():
+def test_ensure_unique_grid() -> None:
 
     columns = ("path", "model", "exp", "table", "varn", "ens", "grid")
 

--- a/filefisher/tests/test_filecontainer.py
+++ b/filefisher/tests/test_filecontainer.py
@@ -229,17 +229,17 @@ def test_fc_combine_by_keys(example_fc) -> None:
     pd.testing.assert_series_equal(result, expected)
 
     result = example_fc._combine_by_keys()
-    expected = map(".".join, example_fc.df.values)
+    expected = list(map(".".join, example_fc.df.values))
     expected = pd.Series(expected, index=example_fc.df.index)
 
     # different sep
     result = example_fc._combine_by_keys(sep="|")
-    expected = map("|".join, example_fc.df.values)
+    expected = list(map("|".join, example_fc.df.values))
     expected = pd.Series(expected, index=example_fc.df.index)
 
     # not all columns
     result = example_fc._combine_by_keys(keys=("model", "res"))
-    expected = map(".".join, example_fc.df[["model", "res"]].values)
+    expected = list(map(".".join, example_fc.df[["model", "res"]].values))
     expected = pd.Series(expected, index=example_fc.df.index)
 
 

--- a/filefisher/tests/test_filecontainer.py
+++ b/filefisher/tests/test_filecontainer.py
@@ -7,7 +7,7 @@ from . import assert_filecontainer_empty
 
 
 @pytest.fixture
-def example_df():
+def example_df() -> pd.DataFrame:
 
     df = pd.DataFrame.from_records(
         [
@@ -24,12 +24,12 @@ def example_df():
 
 
 @pytest.fixture
-def example_fc(example_df):
+def example_fc(example_df) -> FileContainer:
 
     return FileContainer(example_df)
 
 
-def test_empty_filecontainer():
+def test_empty_filecontainer() -> None:
 
     df = pd.DataFrame([], columns=["cat"], index=pd.Index([], name="path"))
 
@@ -42,13 +42,13 @@ def test_empty_filecontainer():
         next(iter(fc.items()))
 
 
-def test_filecontainer(example_df, example_fc):
+def test_filecontainer(example_df, example_fc) -> None:
 
     assert example_fc.df is example_df
     assert len(example_fc) == 5
 
 
-def test_fc_iter(example_df, example_fc):
+def test_fc_iter(example_df, example_fc) -> None:
 
     # test one manually
     with pytest.warns(
@@ -69,7 +69,7 @@ def test_fc_iter(example_df, example_fc):
     assert result == expected
 
 
-def test_fc_items(example_df, example_fc):
+def test_fc_items(example_df, example_fc) -> None:
 
     # test one manually
     path, meta = next(iter(example_fc.items()))
@@ -83,7 +83,7 @@ def test_fc_items(example_df, example_fc):
     assert result == expected
 
 
-def test_fc_getitem(example_df, example_fc):
+def test_fc_getitem(example_df, example_fc) -> None:
 
     # indexing by scalar currently returns path, meta (analog to the loop)
     # not sure if this is the best way but keep for now
@@ -103,7 +103,7 @@ def test_fc_getitem(example_df, example_fc):
     assert_filecontainer_empty(result, columns=["model", "scen", "res"])
 
 
-def test_filecontainer_paths(example_fc):
+def test_filecontainer_paths(example_fc) -> None:
 
     result = example_fc.paths
     expected = [
@@ -117,7 +117,7 @@ def test_filecontainer_paths(example_fc):
     assert result == expected
 
 
-def test_filecontainer_meta(example_fc):
+def test_filecontainer_meta(example_fc) -> None:
 
     result = example_fc.meta
 
@@ -132,7 +132,7 @@ def test_filecontainer_meta(example_fc):
     assert result == expected
 
 
-def test_filecontainer_search(example_df, example_fc):
+def test_filecontainer_search(example_df, example_fc) -> None:
 
     with pytest.raises(KeyError):
         example_fc.search(not_in_example_fc="a")
@@ -163,7 +163,7 @@ def test_filecontainer_search(example_df, example_fc):
     pd.testing.assert_frame_equal(result.df, expected)
 
 
-def test_filecontainer_search_none_key(example_df, example_fc):
+def test_filecontainer_search_none_key(example_df, example_fc) -> None:
     # https://github.com/mpytools/filefisher/issues/156
 
     result = example_fc.search(model=None)
@@ -174,7 +174,7 @@ def test_filecontainer_search_none_key(example_df, example_fc):
     pd.testing.assert_frame_equal(result.df, expected)
 
 
-def test_filecontainer_search_single(example_df, example_fc):
+def test_filecontainer_search_single(example_df, example_fc) -> None:
 
     # empty search query results in an empty FileContainer
     with pytest.raises(ValueError, match="Found no paths"):
@@ -191,7 +191,7 @@ def test_filecontainer_search_single(example_df, example_fc):
     pd.testing.assert_frame_equal(result.df, expected)
 
 
-def test_filecontainer_concat(example_fc):
+def test_filecontainer_concat(example_fc) -> None:
 
     with pytest.raises(ValueError, match="Can only concatenate two FileContainers."):
         example_fc.concat("not a FileContainer")
@@ -214,13 +214,13 @@ def test_filecontainer_concat(example_fc):
     assert len(result) == 5
 
 
-def test_fc_combine_by_key_deprecated(example_fc):
+def test_fc_combine_by_key_deprecated(example_fc) -> None:
 
     with pytest.warns(FutureWarning, match="`combine_by_key` has been deprecated"):
         example_fc[[0]].combine_by_key()
 
 
-def test_fc_combine_by_keys(example_fc):
+def test_fc_combine_by_keys(example_fc) -> None:
 
     result = example_fc[[0]]._combine_by_keys()
 
@@ -243,7 +243,7 @@ def test_fc_combine_by_keys(example_fc):
     expected = pd.Series(expected, index=example_fc.df.index)
 
 
-def test_filefinder_repr(example_fc):
+def test_filefinder_repr(example_fc) -> None:
 
     # NOTE: does not test the pd.DataFrame part of the repr
 

--- a/filefisher/tests/test_filefinder.py
+++ b/filefisher/tests/test_filefinder.py
@@ -49,7 +49,7 @@ def test_paths(request, tmp_path):
 
 
 @pytest.mark.parametrize("placeholder", ("keys", "on_parse_error", "_allow_empty"))
-def test_pattern_invalid_placeholder(placeholder):
+def test_pattern_invalid_placeholder(placeholder) -> None:
 
     with pytest.raises(ValueError, match=f"'{placeholder}' is not a valid placeholder"):
         FileFinder("", f"{{{placeholder}}}")
@@ -59,7 +59,7 @@ def test_pattern_invalid_placeholder(placeholder):
 
 
 @pytest.mark.parametrize("pattern", ("{}", "{_fixed}"))
-def test_only_named_fields(pattern):
+def test_only_named_fields(pattern) -> None:
 
     with pytest.raises(ValueError, match="Only named fields are currently allowed"):
         FileFinder("", pattern)
@@ -68,7 +68,7 @@ def test_only_named_fields(pattern):
         FileFinder(pattern, "")
 
 
-def test_assert_unique():
+def test_assert_unique() -> None:
 
     # no error raised
     df = pd.DataFrame.from_records([("a", "d"), ("a", "h")], columns=("model", "res"))
@@ -80,7 +80,7 @@ def test_assert_unique():
 
 
 @pytest.mark.parametrize("_allow_empty", (False, True))
-def test_deprecate_allow_empty(_allow_empty):
+def test_deprecate_allow_empty(_allow_empty) -> None:
 
     ff = FileFinder("", "a")
     msg = "`_allow_empty` has been deprecated in favour of `on_empty`"
@@ -91,18 +91,18 @@ def test_deprecate_allow_empty(_allow_empty):
         ff.find_paths(_allow_empty=_allow_empty)
 
 
-def test_wrong_on_empty():
+def test_wrong_on_empty() -> None:
 
     ff = FileFinder("", "a")
     msg = "Unknown value for 'on_empty': 'null'. Must be one of 'raise', 'warn' or 'allow'."
     with pytest.raises(ValueError, match=msg):
-        ff.find_paths(on_empty="null")
+        ff.find_paths(on_empty="null")  # type: ignore[arg-type]
 
     with pytest.raises(ValueError, match=msg):
-        ff.find_files(on_empty="null")
+        ff.find_files(on_empty="null")  # type: ignore[arg-type]
 
 
-def test_pattern_property():
+def test_pattern_property() -> None:
 
     path_pattern = "path_pattern/"
     file_pattern = "file_pattern"
@@ -120,7 +120,7 @@ def test_pattern_property():
     assert ff.full.pattern == path_pattern + file_pattern
 
 
-def test_test_path_property():
+def test_test_path_property() -> None:
 
     ff = FileFinder("a", "b")
 
@@ -133,7 +133,7 @@ def test_test_path_property():
     assert ff._test_paths == ["a", "b"]
 
 
-def test_test_path_assert_nonunique():
+def test_test_path_assert_nonunique() -> None:
 
     with pytest.raises(ValueError, match="`test_paths` are not unique"):
         FileFinder("a", "", test_paths=["a", "a"])
@@ -145,7 +145,7 @@ def test_test_path_assert_nonunique():
         FileFinder("a", "", test_paths=["a/b", "a/b"])
 
 
-def test_file_pattern_no_sep():
+def test_file_pattern_no_sep() -> None:
 
     path_pattern = "path_pattern"
     file_pattern = "file" + os.path.sep + "pattern"
@@ -154,7 +154,7 @@ def test_file_pattern_no_sep():
         FileFinder(path_pattern=path_pattern, file_pattern=file_pattern)
 
 
-def test_pattern_sep_added():
+def test_pattern_sep_added() -> None:
 
     path_pattern = "path_pattern"
     file_pattern = "file_pattern"
@@ -163,7 +163,7 @@ def test_pattern_sep_added():
     assert ff.path_pattern == path_pattern + os.path.sep
 
 
-def test_keys():
+def test_keys() -> None:
 
     file_pattern = "{a}_{b}_{c}"
     path_pattern = "{ab}_{c}"
@@ -179,7 +179,7 @@ def test_keys():
     assert ff.keys_path == expected
 
 
-def test_repr():
+def test_repr() -> None:
 
     path_pattern = "/{a}/{b}"
     file_pattern = "{b}_{c}"
@@ -210,7 +210,7 @@ def test_repr():
     assert expected == ff.__repr__()
 
 
-def test_repr_test_paths():
+def test_repr_test_paths() -> None:
 
     path_pattern = "/{a}/{b}"
     file_pattern = "{b}_{c}"
@@ -250,7 +250,7 @@ def test_repr_test_paths():
     assert expected == ff.__repr__()
 
 
-def test_create_name():
+def test_create_name() -> None:
 
     path_pattern = "{a}/{b}"
     file_pattern = "{b}_{c}"
@@ -266,7 +266,7 @@ def test_create_name():
     assert result == "a/b/b_c"
 
 
-def test_create_name_dict():
+def test_create_name_dict() -> None:
 
     path_pattern = "{a}/{b}"
     file_pattern = "{b}_{c}"
@@ -282,7 +282,7 @@ def test_create_name_dict():
     assert result == "a/b/b_c"
 
 
-def test_create_name_kwargs_priority():
+def test_create_name_kwargs_priority() -> None:
 
     path_pattern = "{a}/{b}"
     file_pattern = "{b}_{c}"
@@ -298,7 +298,7 @@ def test_create_name_kwargs_priority():
     assert result == "a/b/b_c"
 
 
-def test_find_path_none_found(tmp_path, test_paths):
+def test_find_path_none_found(tmp_path, test_paths) -> None:
 
     path_pattern = tmp_path / "{a}/foo/"
     file_pattern = "file_pattern"
@@ -328,7 +328,7 @@ def test_find_path_none_found(tmp_path, test_paths):
     assert_filecontainer_empty(result, columns="a")
 
 
-def test_find_paths_non_unique():
+def test_find_paths_non_unique() -> None:
 
     # ensure find_paths works for duplicated folder names (made unique by the file name)
 
@@ -341,7 +341,7 @@ def test_find_paths_non_unique():
     pd.testing.assert_frame_equal(result.df, expected)
 
 
-def test_find_paths_simple(tmp_path, test_paths):
+def test_find_paths_simple(tmp_path, test_paths) -> None:
 
     path_pattern = tmp_path / "a1/{a}/"
     file_pattern = "file_pattern"
@@ -363,7 +363,7 @@ def test_find_paths_simple(tmp_path, test_paths):
     pd.testing.assert_frame_equal(result.df, expected)
 
 
-def test_find_paths_none_key_ignored():
+def test_find_paths_none_key_ignored() -> None:
 
     ff = FileFinder("{folder}", "", test_paths=["a/"])
 
@@ -375,7 +375,7 @@ def test_find_paths_none_key_ignored():
 
 
 @pytest.mark.parametrize("find_kwargs", [{"b": "foo"}, {"a": "*", "b": "foo"}])
-def test_find_paths_wildcard(tmp_path, test_paths, find_kwargs):
+def test_find_paths_wildcard(tmp_path, test_paths, find_kwargs) -> None:
 
     path_pattern = tmp_path / "{a}/{b}"
     file_pattern = "file_pattern"
@@ -405,7 +405,7 @@ def test_find_paths_wildcard(tmp_path, test_paths, find_kwargs):
     "find_kwargs",
     [{"a": ["a1", "a2"], "b": "foo"}, {"a": ["a1", "a2"], "b": ["foo", "bar"]}],
 )
-def test_find_paths_several(tmp_path, test_paths, find_kwargs):
+def test_find_paths_several(tmp_path, test_paths, find_kwargs) -> None:
 
     path_pattern = tmp_path / "{a}/{b}"
     file_pattern = "file_pattern"
@@ -435,7 +435,7 @@ def test_find_paths_several(tmp_path, test_paths, find_kwargs):
     "find_kwargs",
     [{"a": "a1"}, {"a": "a1", "b": "foo"}, {"a": "a1", "b": ["foo", "bar"]}],
 )
-def test_find_paths_one_of_several(tmp_path, test_paths, find_kwargs):
+def test_find_paths_one_of_several(tmp_path, test_paths, find_kwargs) -> None:
 
     path_pattern = tmp_path / "{a}/{b}"
     file_pattern = "file_pattern"
@@ -461,7 +461,7 @@ def test_find_paths_one_of_several(tmp_path, test_paths, find_kwargs):
     pd.testing.assert_frame_equal(result.df, expected)
 
 
-def test_find_single_path(tmp_path, test_paths):
+def test_find_single_path(tmp_path, test_paths) -> None:
 
     path_pattern = tmp_path / "{a}/foo"
     file_pattern = "file_pattern"
@@ -488,7 +488,7 @@ def test_find_single_path(tmp_path, test_paths):
     pd.testing.assert_frame_equal(result.df, expected)
 
 
-def test_find_file_none_found(tmp_path, test_paths):
+def test_find_file_none_found(tmp_path, test_paths) -> None:
 
     path_pattern = tmp_path / "{a}/foo/"
     file_pattern = "{file_pattern}"
@@ -521,7 +521,7 @@ def test_find_file_none_found(tmp_path, test_paths):
     assert_filecontainer_empty(result, columns=("a", "file_pattern"))
 
 
-def test_find_files_non_unique():
+def test_find_files_non_unique() -> None:
 
     # test raises error for non-unique metadata - AFAIK not possible for real paths
 
@@ -533,7 +533,7 @@ def test_find_files_non_unique():
         ff.find_files()
 
 
-def test_find_file_simple(tmp_path, test_paths):
+def test_find_file_simple(tmp_path, test_paths) -> None:
 
     path_pattern = tmp_path / "a1/{a}/"
     file_pattern = "file"
@@ -555,7 +555,7 @@ def test_find_file_simple(tmp_path, test_paths):
     pd.testing.assert_frame_equal(result.df, expected)
 
 
-def test_find_file_none_key_ignored():
+def test_find_file_none_key_ignored() -> None:
 
     ff = FileFinder("", "{file}", test_paths=["a"])
 
@@ -568,7 +568,7 @@ def test_find_file_none_key_ignored():
 
 
 @pytest.mark.parametrize("find_kwargs", [{"b": "file"}, {"a": "*", "b": "file"}])
-def test_find_files_wildcard(tmp_path, test_paths, find_kwargs):
+def test_find_files_wildcard(tmp_path, test_paths, find_kwargs) -> None:
 
     path_pattern = tmp_path / "{a}/foo"
     file_pattern = "{b}"
@@ -601,7 +601,7 @@ def test_find_files_wildcard(tmp_path, test_paths, find_kwargs):
     "find_kwargs",
     [{"a": ["a1", "a2"], "b": "file"}, {"a": ["a1", "a2"], "b": ["file", "bar"]}],
 )
-def test_find_files_several(tmp_path, test_paths, find_kwargs):
+def test_find_files_several(tmp_path, test_paths, find_kwargs) -> None:
 
     path_pattern = tmp_path / "{a}/foo"
     file_pattern = "{b}"
@@ -634,7 +634,7 @@ def test_find_files_several(tmp_path, test_paths, find_kwargs):
     "find_kwargs",
     [{"a": "a1"}, {"a": "a1", "b": "file"}, {"a": "a1", "b": ["file", "bar"]}],
 )
-def test_find_files_one_of_several(tmp_path, test_paths, find_kwargs):
+def test_find_files_one_of_several(tmp_path, test_paths, find_kwargs) -> None:
 
     path_pattern = tmp_path / "{a}/foo"
     file_pattern = "{b}"
@@ -660,7 +660,7 @@ def test_find_files_one_of_several(tmp_path, test_paths, find_kwargs):
     pd.testing.assert_frame_equal(result.df, expected)
 
 
-def test_find_single_file(tmp_path, test_paths):
+def test_find_single_file(tmp_path, test_paths) -> None:
 
     path_pattern = tmp_path / "{a}/foo"
     file_pattern = "file"
@@ -687,7 +687,7 @@ def test_find_single_file(tmp_path, test_paths):
     pd.testing.assert_frame_equal(result.df, expected)
 
 
-def test_find_paths_scalar_number():
+def test_find_paths_scalar_number() -> None:
 
     ff = FileFinder(
         path_pattern="{path}", file_pattern="{file}", test_paths=["1/1", "2/2"]
@@ -699,7 +699,7 @@ def test_find_paths_scalar_number():
     pd.testing.assert_frame_equal(result.df, expected)
 
 
-def test_find_files_scalar_number():
+def test_find_files_scalar_number() -> None:
 
     ff = FileFinder(
         path_pattern="{path}", file_pattern="{file}", test_paths=["1/1", "2/2"]
@@ -711,7 +711,7 @@ def test_find_files_scalar_number():
     pd.testing.assert_frame_equal(result.df, expected)
 
 
-def test_find_unparsable():
+def test_find_unparsable() -> None:
 
     ff = FileFinder("{cat}", "{cat}", test_paths=["a/b"])
 
@@ -748,7 +748,7 @@ def test_find_unparsable():
         ValueError,
         match="Unknown value for 'on_parse_error': 'foo'. Must be one of 'raise', 'warn' or 'ignore'.",
     ):
-        ff.find_files(on_parse_error="foo")
+        ff.find_files(on_parse_error="foo")  # type: ignore[arg-type]
 
     ff = FileFinder("", "{cat}_{cat}", test_paths=["a_b"])
 
@@ -760,7 +760,7 @@ def test_find_unparsable():
     ff = FileFinder("{cat}_{cat}", "", test_paths=["a_b/"])
 
     with pytest.raises(
-        ValueError, match="Could not parse 'a_b/' with the pattern '{cat}_{cat}'"
+        ValueError, match="Could not parse 'a_b/' with the pattern '{cat}_{cat}/'"
     ):
         ff.find_files()
 

--- a/filefisher/tests/test_filefinder_fmt.py
+++ b/filefisher/tests/test_filefinder_fmt.py
@@ -1,24 +1,11 @@
 import textwrap
 
 import pandas as pd
-import pytest
 
 from filefisher import FileFinder
 
 
-@pytest.fixture(scope="module", params=["from_filesystem", "from_string"])
-def test_paths(request, tmp_path):
-
-    if request.param == "from_filesystem":
-        return None
-
-    paths = ["a1/foo/file", "a2/foo/file"]
-    paths = [str(tmp_path / path) for path in paths]
-
-    return paths
-
-
-def test_pattern_no_fmt_spec():
+def test_pattern_no_fmt_spec() -> None:
 
     path_pattern = "{path:l}_{pattern:2d}_{no_fmt}/"
     file_pattern = "{file}_{pattern:2d}"
@@ -34,7 +21,7 @@ def test_pattern_no_fmt_spec():
     assert ff.full._pattern_no_fmt_spec == path_pattern_no_fmt + file_pattern_no_fmt
 
 
-def test_keys():
+def test_keys() -> None:
 
     file_pattern = "{a:l}_{b}_{c:d}"
     path_pattern = "{ab}_{c:d}"
@@ -50,7 +37,7 @@ def test_keys():
     assert ff.keys_path == expected
 
 
-def test_repr():
+def test_repr() -> None:
 
     path_pattern = "/{a:l}/{b}"
     file_pattern = "{b}_{c:d}"
@@ -67,7 +54,7 @@ def test_repr():
     assert expected == ff.__repr__()
 
 
-def test_create_name():
+def test_create_name() -> None:
 
     path_pattern = "{a:w}/{b}"
     file_pattern = "{b}_{c:l}"
@@ -83,7 +70,7 @@ def test_create_name():
     assert result == "a/b/b_c"
 
 
-def test_create_name_dict():
+def test_create_name_dict() -> None:
 
     path_pattern = "{a:w}/{b}"
     file_pattern = "{b}_{c:d}"
@@ -99,7 +86,7 @@ def test_create_name_dict():
     assert result == "a/b/b_c"
 
 
-def test_find_paths_fmt():
+def test_find_paths_fmt() -> None:
 
     test_paths = ["a1/a1_abc", "ab200/ab200_aicdef"]
 

--- a/filefisher/tests/test_filelinder_deprecation.py
+++ b/filefisher/tests/test_filelinder_deprecation.py
@@ -5,7 +5,7 @@ import pytest
 from . import assert_no_warnings
 
 
-def test_filefinder_deprecation():
+def test_filefinder_deprecation() -> None:
 
     with pytest.warns(
         FutureWarning, match="`filefinder` has been renamed to `filefisher`"

--- a/filefisher/tests/test_filters.py
+++ b/filefisher/tests/test_filters.py
@@ -9,7 +9,7 @@ from . import assert_no_warnings
 # ({"model": ["a", "a", "b", "c", "c", "d"], "res": ["d", "h", "h", "h", "d", "z"]})
 
 
-def test_priority_filter_errors():
+def test_priority_filter_errors() -> None:
 
     df = pd.DataFrame.from_records(
         [("a", "d")],
@@ -23,7 +23,7 @@ def test_priority_filter_errors():
         priority_filter(df, "res", ["a"], groupby=["model", "res"])
 
 
-def test_priority_filter_simple():
+def test_priority_filter_simple() -> None:
 
     df = pd.DataFrame.from_records(
         [("a", "d"), ("a", "h"), ("b", "h"), ("b", "d"), ("c", "d")],
@@ -39,7 +39,7 @@ def test_priority_filter_simple():
     pd.testing.assert_frame_equal(result, expected)
 
 
-def test_priority_filter_missing():
+def test_priority_filter_missing() -> None:
 
     df = pd.DataFrame.from_records(
         [("a", "d"), ("a", "h"), ("b", "d"), ("c", "z")], columns=("model", "res")
@@ -81,7 +81,7 @@ def test_priority_filter_missing():
     pd.testing.assert_frame_equal(res, expected)
 
 
-def test_priority_filter_duplicates():
+def test_priority_filter_duplicates() -> None:
 
     df = pd.DataFrame.from_records([("a", "d"), ("a", "d")], columns=("model", "res"))
 
@@ -89,7 +89,7 @@ def test_priority_filter_duplicates():
         priority_filter(df, "res", ["h", "d"])
 
 
-def test_priority_filter_multi():
+def test_priority_filter_multi() -> None:
 
     df = pd.DataFrame.from_records(
         [("a", 1, "d"), ("a", 2, "d"), ("a", 1, "h"), ("b", 1, "h")],
@@ -103,7 +103,7 @@ def test_priority_filter_multi():
     pd.testing.assert_frame_equal(result, expected)
 
 
-def test_priority_filter_groupby():
+def test_priority_filter_groupby() -> None:
 
     df = pd.DataFrame.from_records(
         [("a", 1, "d"), ("a", 2, "h"), ("b", 1, "h"), ("b", 2, "d")],
@@ -124,7 +124,7 @@ def test_priority_filter_groupby():
     pd.testing.assert_frame_equal(result, expected)
 
 
-def test_priority_filter_filename():
+def test_priority_filter_filename() -> None:
     """the filename is per default unique -> must be excluded from groupby"""
     df = pd.DataFrame.from_records(
         [
@@ -147,7 +147,7 @@ def test_priority_filter_filename():
     pd.testing.assert_frame_equal(result, expected)
 
 
-def test_priority_filter_filecontainer_simple():
+def test_priority_filter_filecontainer_simple() -> None:
     """the filename is per default unique -> must be excluded from groupby"""
     df = pd.DataFrame.from_records(
         [

--- a/filefisher/tests/test_utils.py
+++ b/filefisher/tests/test_utils.py
@@ -20,21 +20,21 @@ from filefisher._utils import (
         ["{a:d}{b:d}{c:d}", ("a", "b", "c")],
     ),
 )
-def test_find_keys(string, expected):
+def test_find_keys(string, expected) -> None:
 
     result = _find_keys(string)
 
     assert result == expected
 
 
-def test_atoi():
+def test_atoi() -> None:
 
     assert atoi("10") == 10
     assert atoi("a10") == "a10"
     assert atoi("a") == "a"
 
 
-def test_natural_keys_sort():
+def test_natural_keys_sort() -> None:
 
     lst = ["a10", "a1"]
     expected = ["a1", "a10"]
@@ -44,7 +44,7 @@ def test_natural_keys_sort():
     assert lst == expected
 
 
-def test_product_dict():
+def test_product_dict() -> None:
 
     result = list(product_dict(a=[1, 2], b=[3, 4], c=[5]))
     expected = [
@@ -57,7 +57,7 @@ def test_product_dict():
     assert result == expected
 
 
-def test_update_dict_with_kwargs():
+def test_update_dict_with_kwargs() -> None:
 
     result = update_dict_with_kwargs({"a": 1}, a=2)
     expected = {"a": 2}
@@ -82,4 +82,4 @@ def test_update_dict_with_kwargs():
         update_dict_with_kwargs("")
 
     with pytest.raises(TypeError, match="missing 1 required positional argument"):
-        update_dict_with_kwargs(dictionary={})
+        update_dict_with_kwargs(dictionary={})  # type: ignore[call-arg]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ exclude = [
 ]
 files = "filefisher"
 
+allow_redefinition = true
 show_error_context = true
 warn_redundant_casts = true
 warn_unused_configs = true


### PR DESCRIPTION

- [x] closes #165
- [ ] There are two functional changes. will do separate PRs for that. 

The main motivation is to add `PathLike` to `path_pattern`. This works (because of `os.path.join`) but is not typed as such. This is not going to be fun once we do #22.