### PR TITLE
fix folder name for empty `file_pattern`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## v1.3.0 - unreleased
 
+- Fix folder names when an empty string is passed as `file_pattern`. Now correctly sets it
+  as `folder/` while it was `folder` previously ([#254](https://github.com/mpytools/filefisher/pull/254)).
 - Added a html repr for `FileContainer` ([#144](https://github.com/mpytools/filefisher/issues/144)).
-
-
 
 ## v1.2.0 - 17.11.2025
 

--- a/filefisher/_filefinder.py
+++ b/filefisher/_filefinder.py
@@ -291,7 +291,7 @@ class FileFinder:
         self.file = _FinderBase(file_pattern)
         # ensure path_pattern ends with a /
         self.path = _Finder(os.path.join(path_pattern, ""), suffix="*")
-        self.full = _Finder(os.path.join(*filter(None, (path_pattern, file_pattern))))
+        self.full = _Finder(os.path.join(path_pattern, file_pattern))
 
         self.keys_path = self.path.keys
         self.keys_file = self.file.keys

--- a/filefisher/tests/test_filefinder.py
+++ b/filefisher/tests/test_filefinder.py
@@ -265,6 +265,30 @@ def test_create_name():
     result = ff.create_full_name(a="a", b="b", c="c")
     assert result == "a/b/b_c"
 
+    # empty file pattern
+    ff = FileFinder(path_pattern=path_pattern, file_pattern="")
+
+    result = ff.create_path_name(a="a", b="b")
+    assert result == "a/b/"
+
+    result = ff.create_file_name()
+    assert result == ""
+
+    result = ff.create_full_name(a="a", b="b")
+    assert result == "a/b/"
+
+    # empty path pattern
+    ff = FileFinder(path_pattern="", file_pattern=file_pattern)
+
+    result = ff.create_path_name()
+    assert result == ""
+
+    result = ff.create_file_name(b="b", c="c")
+    assert result == "b_c"
+
+    result = ff.create_full_name(a="a", b="b", c="c")
+    assert result == "b_c"
+
 
 def test_create_name_dict():
 
@@ -760,7 +784,7 @@ def test_find_unparsable():
     ff = FileFinder("{cat}_{cat}", "", test_paths=["a_b/"])
 
     with pytest.raises(
-        ValueError, match="Could not parse 'a_b/' with the pattern '{cat}_{cat}'"
+        ValueError, match="Could not parse 'a_b/' with the pattern '{cat}_{cat}/'"
     ):
         ff.find_files()
 


### PR DESCRIPTION
I removed the filter - previously an empty `path_pattern` and `file_pattern` was removed and no trailing `/` was added to the `path_pattern`.